### PR TITLE
Provide quick start guidelines for the CurrentTime demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,32 @@ Feedback is welcome!
 ## Quickstart
 
 This demo requires Docker on your machine.
-Docker for Windows and Docker for Mac are also fine.   
+_Docker for Windows_ and _Docker for Mac_ will also do the job.   
+
+To get started, clone this repository to your local computer and go into itsroot directory.
+Then build the demo project:
+
+```bash
+mvn -f demo/currentTime/cli-app/ clean package
+```
 
 Run the following command:
 
 ```bash
-docker pull ghcr.io/oleg-nenashev/faascinator:main
-docker run --rm -p 8080:8080 ghcr.io/oleg-nenashev/faascinator:main
+docker run --rm -p 8080:8080 \
+	-v $(pwd)/demo/currentTime/cli-app/target/demo-current-time.jar:/app/payload.jar \
+ 	-e QUARKUS_FAASCINATOR_DESCRIPTION="Shows the current time" \
+	-e QUARKUS_FAASCINATOR_CLIJAR=/app/payload.jar \
+	-e QUARKUS_FAASCINATOR_MAINCLASS="io.faascinator.demo.currenttime.CurrentTime" \
+	ghcr.io/oleg-nenashev/faascinator:main
 ```
 
 The command will start the image and expose the API server on port `8080`.
 Then you can:
 
 1. Get current time by opening http://localhost:8080
-2. Get help by opening http://localhost:8080/help
+2. Get current time in Zurich timezone by opening http://localhost:8080/?arg=Europe/Zurich
+3. Get help by opening http://localhost:8080/help
 
 ## Usage
 

--- a/demo/currentTime/Makefile
+++ b/demo/currentTime/Makefile
@@ -6,4 +6,11 @@ build:
 run-local:
 	java -jar ../../function/3_service/target/quarkus-app/quarkus-run.jar
 
-#TODO: Add Docker run
+.PHONY: run-docker
+run-docker:
+	docker run --rm -p 8080:8080 \
+	   -v $(CURDIR)/cli-app/target/demo-current-time.jar:/app/payload.jar \
+ 	   -e QUARKUS_FAASCINATOR_DESCRIPTION="Shows the current time" \
+	   -e QUARKUS_FAASCINATOR_CLIJAR=/app/payload.jar \
+	   -e QUARKUS_FAASCINATOR_MAINCLASS="io.faascinator.demo.currenttime.CurrentTime" \
+	   ghcr.io/oleg-nenashev/faascinator:main

--- a/demo/currentTime/README.md
+++ b/demo/currentTime/README.md
@@ -2,6 +2,11 @@
 
 1. Ensure that FaaScinator is packaged
 2. Run `make build` to build the demo
-3. Run `make run-local` to run the demo locally
+3. Run `make run-local` to run the demo locally or `make run-docker` to run the demo in Docker container
 
-Support for Docker runs is coming soon.
+The command will start the image and expose the API server on port `8080`.
+Then you can:
+
+1. Get current time by opening http://localhost:8080
+2. Get current time in Zurich timezone by opening http://localhost:8080/?arg=Europe/Zurich
+3. Get help by opening http://localhost:8080/help

--- a/demo/currentTime/cli-app/pom.xml
+++ b/demo/currentTime/cli-app/pom.xml
@@ -100,4 +100,31 @@
     </plugins>
   </build>
 
+  <!-- TODO: Do not depend on Jenkins parent POM? -->
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+
 </project>


### PR DESCRIPTION
Updates docs so that they demonstrate usage of external JAR with dependencies