### PR TITLE
Update from  Quarkus 1.13.0 to 2.0.1 + Use Java 11 as a target and minimum requirement

### DIFF
--- a/function/3_service/pom.xml
+++ b/function/3_service/pom.xml
@@ -57,6 +57,7 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
+      <version>${spotbugs.version}</version>
     </dependency>
 
     <dependency>

--- a/function/3_service/src/main/java/io/faascinator/service/HelpResource.java
+++ b/function/3_service/src/main/java/io/faascinator/service/HelpResource.java
@@ -1,10 +1,5 @@
 package io.faascinator.service;
 
-/**
- * Prints help for the method
- * @author Oleg Nenashev
- * @since TODO
- */
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.faascinator.service.util.PicocliExtractor;
 import picocli.CommandLine;
@@ -19,6 +14,11 @@ import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
+/**
+ * Prints help for the method
+ * @author Oleg Nenashev
+ * @since TODO
+ */
 @Path("/help")
 public class HelpResource extends FaaScinatorResource {
 

--- a/function/3_service/src/main/java/io/faascinator/service/MainResource.java
+++ b/function/3_service/src/main/java/io/faascinator/service/MainResource.java
@@ -32,7 +32,7 @@ public class MainResource extends FaaScinatorResource {
         return runSubcommand(null, args);
     }
 
-        //TODO: fix it
+    //TODO: fix it
     @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "hack")
     @GET
     @Path("/run/{subcommand}")

--- a/function/8_demo-picocli/pom.xml
+++ b/function/8_demo-picocli/pom.xml
@@ -41,6 +41,7 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
+      <version>${spotbugs.version}</version>
     </dependency>
   </dependencies>
 
@@ -49,6 +50,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
         <configuration>
           <annotationProcessorPaths>
             <path>

--- a/function/pom.xml
+++ b/function/pom.xml
@@ -1,13 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.jenkins-ci</groupId>
-    <artifactId>jenkins</artifactId>
-    <version>1.64</version>
-    <relativePath/>
-  </parent>
-
   <groupId>io.faascinator</groupId>
   <artifactId>faascinator-parent</artifactId>
   <version>1.0-alpha-1-SNAPSHOT</version>
@@ -15,6 +8,7 @@
 
   <name>FaaScinator Parent POM</name>
   <description>Parent POM for FaaScinator components</description>
+  <inceptionYear>2021</inceptionYear>
   <url>https://github.com/oleg-nenashev/FaaScinator</url>
 
   <licenses>
@@ -34,27 +28,18 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.level>8</java.level>
+    <java.level>11</java.level>
+    <java.level.test>11</java.level.test>
     <gitHubRepo>oleg-nenashev/FaaScinator</gitHubRepo>
+
     <enforcer.skip>true</enforcer.skip>
+    <spotbugs.version>4.3.0</spotbugs.version>
+    <spotbugs.failOnError>true</spotbugs.failOnError>
+    <spotbugs.threshold>Medium</spotbugs.threshold>
+    <spotbugs.effort>default</spotbugs.effort>
 
-    <quarkus.version>1.13.0.Final</quarkus.version>
+    <quarkus.version>2.0.0.Final</quarkus.version>
   </properties>
-
-
-  <repositories>
-    <repository>
-      <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/public/</url>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/public/</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <scm>
     <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
@@ -62,6 +47,131 @@
     <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>
   </scm>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>4.2.0</version>
+        <configuration>
+          <failOnError>${spotbugs.failOnError}</failOnError>
+          <xmlOutput>true</xmlOutput>
+          <spotbugsXmlOutput>false</spotbugsXmlOutput>
+          <effort>${spotbugs.effort}</effort>
+          <threshold>${spotbugs.threshold}</threshold>
+          <plugins>
+            <plugin>
+              <groupId>com.h3xstream.findsecbugs</groupId>
+              <artifactId>findsecbugs-plugin</artifactId>
+              <version>1.11.0</version>
+            </plugin>
+          </plugins>
+        </configuration>
+        <executions>
+          <execution>
+            <id>spotbugs</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M3</version>
+        <executions>
+          <execution>
+            <id>display-info</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>display-info</goal>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.6.3,)</version>
+                  <message>3.6.3 is required at least.</message>
+                </requireMavenVersion>
+                <requirePluginVersions>
+                  <banSnapshots>true</banSnapshots>
+                </requirePluginVersions>
+                <requireJavaVersion>
+                  <version>[${java.level}.0,]</version>
+                </requireJavaVersion>
+                <requireUpperBoundDeps />
+                <enforceBytecodeVersion>
+                  <maxJdkVersion>1.${java.level}</maxJdkVersion>
+                  <ignoredScopes>
+                    <ignoredScope>test</ignoredScope>
+                  </ignoredScopes>
+                  <excludes>
+                    <!--  findbugs dep managed to provided and optional so is not shipped and missing annotations ok -->
+                    <exclude>com.github.spotbugs:spotbugs-annotations</exclude>
+                    <exclude>com.google.code.findbugs:annotations</exclude>
+                  </excludes>
+                  <!-- To add exclusions in a child POM, use:
+                  <plugin>
+                      <artifactId>maven-enforcer-plugin</artifactId>
+                      <executions>
+                          <execution>
+                              <id>display-info</id>
+                              <configuration>
+                                  <rules>
+                                      <enforceBytecodeVersion>
+                                          <excludes combine.children="append">
+                                              <exclude>…</exclude>
+                                          </excludes>
+                                      </enforceBytecodeVersion>
+                                  </rules>
+                              </configuration>
+                          </execution>
+                      </executions>
+                  </plugin>
+                  (or just override java.level) -->
+                </enforceBytecodeVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>extra-enforcer-rules</artifactId>
+            <version>1.3</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>1.20</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <id>check</id>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>${java.level}</source>
+          <target>${java.level}</target>
+          <testSource>${java.level.test}</testSource>
+          <testTarget>${java.level.test}</testTarget>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <profiles>
     <profile>

--- a/function/pom.xml
+++ b/function/pom.xml
@@ -38,7 +38,7 @@
     <spotbugs.threshold>Medium</spotbugs.threshold>
     <spotbugs.effort>default</spotbugs.effort>
 
-    <quarkus.version>2.0.0.Final</quarkus.version>
+    <quarkus.version>2.0.1.Final</quarkus.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
Reverts oleg-nenashev/FaaScinator#25 and restores #23 so that it can be properly tested before the merge.

Closes #19 